### PR TITLE
Improve casino bet amount parser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "duck-duck-bot"
-version = "1.18.11"
+version = "1.18.12"
 description = ""
 authors = ["Eldos <eldos.baktybekov@gmail.com>"]
 readme = "README.md"

--- a/src/filters/casino.py
+++ b/src/filters/casino.py
@@ -1,6 +1,7 @@
 from aiogram.types import Message
 
 from models import BetColor, BetEvenOrOdd
+from services import parse_abbreviated_number
 
 __all__ = (
     'bet_on_specific_number_filter',
@@ -22,18 +23,20 @@ def bet_on_specific_number_filter(message: Message) -> bool | dict:
 
     _, target_number, amount = args
 
-    target_number: str
-    amount: str
-
-    if not (target_number.isdigit() and amount.isdigit()):
+    try:
+        target_number = int(target_number)
+    except ValueError:
         return False
-
-    target_number: int = int(target_number)
 
     if not (0 <= target_number <= 36):
         return False
 
-    return {'target_number': target_number, 'bet_amount': int(amount)}
+    try:
+        amount = parse_abbreviated_number(amount)
+    except ValueError:
+        return False
+
+    return {'target_number': target_number, 'bet_amount': amount}
 
 
 def bet_on_specific_color_filter(message: Message) -> bool | dict:
@@ -47,7 +50,12 @@ def bet_on_specific_color_filter(message: Message) -> bool | dict:
     if color not in set(BetColor):
         return False
 
-    return {'target_color': BetColor(color), 'bet_amount': int(amount)}
+    try:
+        amount = parse_abbreviated_number(amount)
+    except ValueError:
+        return False
+
+    return {'target_color': BetColor(color), 'bet_amount': amount}
 
 
 def bet_on_even_or_odd_number_filter(message: Message) -> bool | dict:
@@ -61,7 +69,12 @@ def bet_on_even_or_odd_number_filter(message: Message) -> bool | dict:
     if even_or_odd not in set(BetEvenOrOdd):
         return False
 
+    try:
+        amount = parse_abbreviated_number(amount)
+    except ValueError:
+        return False
+
     return {
         'target_even_or_odd': BetEvenOrOdd(even_or_odd),
-        'bet_amount': int(amount),
+        'bet_amount': amount,
     }

--- a/src/filters/transfers.py
+++ b/src/filters/transfers.py
@@ -1,5 +1,7 @@
 from aiogram.types import Message
 
+from services import parse_abbreviated_number
+
 __all__ = ('transfer_operation_filter',)
 
 
@@ -14,10 +16,8 @@ def transfer_operation_filter(message: Message) -> bool | dict:
         _, amount, *description = args
         description = ' '.join(description)
 
-    amount = amount.replace('к', '000')
-
     try:
-        amount = int(amount)
+        amount = parse_abbreviated_number(amount)
     except ValueError:
         return False
 

--- a/src/services/text.py
+++ b/src/services/text.py
@@ -1,5 +1,23 @@
-__all__ = ('int_gaps',)
+__all__ = ('int_gaps', 'parse_abbreviated_number')
 
 
 def int_gaps(number: str | int) -> str:
     return f'{number:_}'.replace('_', ' ')
+
+
+def parse_abbreviated_number(number: str) -> int:
+    if not number:
+        raise ValueError('Number is empty')
+
+    if not number[0].isdigit():
+        raise ValueError('Number does not start with a digit')
+
+    abbreviations_and_values = (
+        ('k', '000'),
+        ('к', '000'),
+    )
+    for abbreviation, value in abbreviations_and_values:
+        if abbreviation in number:
+            number = number.replace(abbreviation, value)
+
+    return int(number)

--- a/tests/test_services/test_text/test_parse_abbreviated_number.py
+++ b/tests/test_services/test_text/test_parse_abbreviated_number.py
@@ -1,0 +1,38 @@
+import pytest
+
+from services.text import parse_abbreviated_number
+
+
+@pytest.mark.parametrize(
+    'number, expected',
+    [
+        ('1k', 1_000),
+        ('1к', 1_000),
+        ('1кк', 1_000_000),
+        ('1kk', 1_000_000),
+        ('10kk', 10_000_000),
+    ],
+)
+def test_parse_abbreviated_number(number, expected):
+    assert parse_abbreviated_number(number) == expected
+
+
+def test_parse_abbreviated_number_empty():
+    with pytest.raises(ValueError) as error:
+        parse_abbreviated_number('')
+    assert str(error.value) == 'Number is empty'
+
+
+@pytest.mark.parametrize(
+    'number',
+    [
+        'k1',
+        'к1',
+        'k',
+        'к',
+    ],
+)
+def test_parse_abbreviated_number_not_start_with_digit(number):
+    with pytest.raises(ValueError) as error:
+        parse_abbreviated_number(number)
+    assert str(error.value) == 'Number does not start with a digit'


### PR DESCRIPTION
- Add ability to make bet via new syntax:
"/bet {odd or even, number, red or black} 1{k * n}" where k will be converted to '000' and n is multiplicator. For example 1kk is 1 million.